### PR TITLE
Import in tests transformer from lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "prepare": "npm run build",
     "release": "standard-version",
-    "test": "ttsc -p tests/tsconfig.json && node tests/out/core/index.js"
+    "test": "npm run build && ttsc -p tests/tsconfig.json && node tests/out/core/index.js"
   },
   "dependencies": {
     "slash": "^2.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { dirname, relative, resolve } from "path";
 import * as ts from "typescript";
-import slash = require("slash");
+import slash from "slash";
 
 const transformer = <T extends ts.Node>(_: ts.Program) => {
   return (context: ts.TransformationContext) => (rootNode: T) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { dirname, relative, resolve } from "path";
-import * as ts from "typescript";
+import ts from "typescript";
 import slash from "slash";
 
 const transformer = <T extends ts.Node>(_: ts.Program) => {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -13,6 +13,6 @@
 
     "esModuleInterop": true,
 
-    "plugins": [{ "transform": "../src/index.ts" }]
+    "plugins": [{ "transform": "../" }]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
 
     "esModuleInterop": true
   },
-  "exclude": ["tests"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
It is better to test code on release env, I think. As bonus, no need to use different syntax for `slash` import, es6 everywhere )).