### PR TITLE
feat!: use `ts.nodeModuleNameResolver`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,19 +13,6 @@ const transformer = (_program: ts.Program) => (
   const compilerOptions = context.getCompilerOptions();
   const sourceDir = dirname(sourceFile.fileName);
 
-  const implicitExtensions = [".ts", ".d.ts"];
-
-  const allowJs = compilerOptions.allowJs === true;
-  const allowJsx =
-    compilerOptions.jsx !== undefined &&
-    compilerOptions.jsx !== ts.JsxEmit.None;
-  const allowJson = compilerOptions.resolveJsonModule === true;
-
-  allowJs && implicitExtensions.push(".js");
-  allowJsx && implicitExtensions.push(".tsx");
-  allowJs && allowJsx && implicitExtensions.push(".jsx");
-  allowJson && implicitExtensions.push(".json");
-
   const { isDeclarationFile } = sourceFile;
 
   const { baseUrl = "", paths = {} } = compilerOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const transformer = (_program: ts.Program) => (
 
   const { isDeclarationFile } = sourceFile;
 
-  const { baseUrl = "", paths = { "*": ["*"] } } = compilerOptions;
+  const { baseUrl = "", paths = {} } = compilerOptions;
 
   const binds = Object.keys(paths)
     .filter(key => paths[key].length)
@@ -37,7 +37,7 @@ const transformer = (_program: ts.Program) => (
       path: paths[key][0]
     }));
 
-  if (!baseUrl || binds.length === 0) {
+  if (!baseUrl) {
     // There is nothing we can do without baseUrl and paths specified.
     return sourceFile;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,26 +61,25 @@ const transformer = (_program: ts.Program) => (
       compilerOptions,
       ts.sys
     );
+    for (const { regexp, path } of binds) {
+      // only needed to check if is url
+      const match = regexp.exec(moduleName);
+      if (match) {
+        const out = path.replace(/\*/g, match[1]);
+        if (isUrl(out)) {
+          return out;
+        }
+      }
+    }
     if (resolvedModule) {
       const { resolvedFileName, extension } = resolvedModule;
       const resolved = slash(relative(sourceDir, resolvedFileName)).replace(
         `${extension}`,
         ""
-      ); // TODO remove extension from the end
+      );
       return isRelative(resolved) ? resolved : `./${resolved}`;
-    } else {
-      // only needed to check for urls
-      for (const { regexp, path } of binds) {
-        const match = regexp.exec(moduleName);
-        if (match) {
-          const out = path.replace(/\*/g, match[1]);
-          if (isUrl(out)) {
-            return out;
-          }
-        }
-      }
-      return moduleName;
     }
+    return moduleName;
   }
 
   function visit(node: ts.Node): ts.VisitResult<ts.Node> {


### PR DESCRIPTION
BREAKING CHANGE: this change the behavior in some cases because it resolves to the actual file, eg when importing a directory with a `index.ts` file, the result will be the file itself:

```ts
// input
import { ... } from "module"
// output
import  { ... } from "module/index"
```