### PR TITLE
fix: type only imports not deleted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,7 @@ const transformer = (_: ts.Program) => (context: ts.TransformationContext) => (
       ts.isNamedImports
     );
     return name || namedBindings
-      ? ts.updateImportClause(node, name, namedBindings)
+      ? ts.updateImportClause(node, name, namedBindings, node.isTypeOnly)
       : undefined;
   }
   function visitNamedImportBindings(
@@ -273,7 +273,8 @@ const transformer = (_: ts.Program) => (context: ts.TransformationContext) => (
         node.decorators,
         node.modifiers,
         node.exportClause,
-        fileLiteral
+        fileLiteral,
+        node.isTypeOnly
       );
     }
 
@@ -290,7 +291,8 @@ const transformer = (_: ts.Program) => (context: ts.TransformationContext) => (
           node.decorators,
           node.modifiers,
           node.exportClause,
-          fileLiteral
+          fileLiteral,
+          node.isTypeOnly
         )
       : undefined;
   }


### PR DESCRIPTION
It seems to be an issue with the latest version of typescript, the option `isTypeOnly` was not present in previous version and that would cause errors see #48.