### PR TITLE
Goal: add option to overwrite existing modules

### DIFF
--- a/src/utils/resolve-path-update-node.ts
+++ b/src/utils/resolve-path-update-node.ts
@@ -27,10 +27,11 @@ export function resolvePathAndUpdateNode(
     tsInstance.sys
   );
 
-  if (resolvedModule?.isExternalLibraryImport) return node;
+  const overwriteModule : boolean = config.overwriteNodeModules
+  if ( ! overwriteModule && resolvedModule?.isExternalLibraryImport ) return node;
 
   let outputPath: string;
-  if (!resolvedModule) {
+  if ( ( ! resolvedModule || overwriteModule ) ) {
     const maybeURL = failedLookupLocations[0];
     if (!isURL(maybeURL)) return node;
     outputPath = maybeURL;


### PR DESCRIPTION
My goal was to import preact like this:
```typescript
import { render, h } from 'preact';
```
But have my JS code like this:
```javascript
import { render, h } from "https://cdnjs.cloudflare.com/ajax/libs/preact/10.5.7/preact.module.min.js";
```
But instead I was getting
```javascript
import { render, h } from 'preact';
```

So I looked at the code here and made a few changes that solved my problem, I am not sure if this breaks anything else, havent tested it, but it worked to solve my problem, so here it is.

Documentation on the feature/option:

Option: overwriteNodeModules
```json
{
	"transform": "typescript-transform-paths",
	"overwriteNodeModules" : true
}
```
If you wish to replace an import for a package that exists on node_modules you can set the option "overwriteNodeModules".

This can be useful when you are planning to use a cdn like in this example:

```typescript
import { render, h } from 'preact';
```
Becomes:
```javascript
import { render, h } from "https://cdnjs.cloudflare.com/ajax/libs/preact/10.5.7/preact.module.min.js";
```