### PR TITLE
docs: fix broken article author link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ import 'normally-transformed' // This will remain 'normally-transformed', even t
 
 ## Articles
 
-- [Node Consumable Modules With Typescript Paths](https://medium.com/@ole.ersoy/node-consumable-modules-with-typescript-paths-ed88a5f332fa?postPublishedType=initial) by [oleersoy](https://github.com/oleersoy")
+- [Node Consumable Modules With Typescript Paths](https://medium.com/@ole.ersoy/node-consumable-modules-with-typescript-paths-ed88a5f332fa?postPublishedType=initial) by [oleersoy](https://github.com/oleersoy)
 
 ## Project Guidelines for Contributors
 


### PR DESCRIPTION
The link URL has a double quote in the end, preventing it from redirecting properly to the article author GitHub profile