### PR TITLE
fix: Accommodate TS 4.4 paths pattern caching (fixes #114)

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -28,6 +28,10 @@ export default function transformer(
 
     if (!pathsBasePath || !compilerOptions.paths) return (sourceFile: ts.SourceFile) => sourceFile;
 
+    const { configFile, paths } = compilerOptions;
+    // TODO - Remove typecast when tryParsePatterns is recognized (probably after ts v4.4)
+    const { tryParsePatterns } = tsInstance as any;
+
     const tsTransformPathsContext: TsTransformPathsContext = {
       compilerOptions,
       config,
@@ -43,6 +47,10 @@ export default function transformer(
       excludeMatchers: config.exclude?.map((globPattern) => new Minimatch(globPattern, { matchBase: true })),
       parsedCommandLine: createParsedCommandLineForProgram(tsInstance, program),
       outputFileNamesCache: new Map(),
+      pathsPatterns: tryParsePatterns
+        // TODO - Remove typecast when pathPatterns is recognized (probably after ts v4.4)
+        ? (configFile?.configFileSpecs as any)?.pathPatterns || tryParsePatterns(paths)
+        : paths
     };
 
     return (sourceFile: ts.SourceFile) => {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -47,10 +47,11 @@ export default function transformer(
       excludeMatchers: config.exclude?.map((globPattern) => new Minimatch(globPattern, { matchBase: true })),
       parsedCommandLine: createParsedCommandLineForProgram(tsInstance, program),
       outputFileNamesCache: new Map(),
+      // Get paths patterns appropriate for TS compiler version
       pathsPatterns: tryParsePatterns
         // TODO - Remove typecast when pathPatterns is recognized (probably after ts v4.4)
         ? (configFile?.configFileSpecs as any)?.pathPatterns || tryParsePatterns(paths)
-        : paths
+        : tsInstance.getOwnKeys(paths)
     };
 
     return (sourceFile: ts.SourceFile) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import tsThree from "./declarations/typescript3";
-import ts, { CompilerOptions, GetCanonicalFileName, ParsedCommandLine } from "typescript";
+import ts, { CompilerOptions, GetCanonicalFileName, ParsedCommandLine, Pattern } from "typescript";
 import { PluginConfig } from "ts-patch";
 import { HarmonyFactory } from "./utils/harmony-factory";
 import { IMinimatch } from "minimatch";
@@ -51,6 +51,7 @@ export interface TsTransformPathsContext {
   readonly outputFileNamesCache: Map<string, string>;
   readonly pathsBasePath: string;
   readonly getCanonicalFileName: GetCanonicalFileName;
+  readonly pathsPatterns: (string | Pattern)[]
 }
 
 export interface VisitorContext extends TsTransformPathsContext {

--- a/src/utils/ts-helpers.ts
+++ b/src/utils/ts-helpers.ts
@@ -65,8 +65,9 @@ export function getOutputFile(context: VisitorContext, fileName: string): string
  * Determine if moduleName matches config in paths
  */
 export function isModulePathsMatch(context: VisitorContext, moduleName: string): boolean {
-  const { matchPatternOrExact, getOwnKeys } = context.tsInstance;
-  return !!matchPatternOrExact(getOwnKeys(context.compilerOptions.paths!), moduleName);
+  const { pathsPatterns, tsInstance: { matchPatternOrExact }} = context
+  // TODO - Remove typecast after ts v4.4
+  return !!matchPatternOrExact((pathsPatterns as any), moduleName);
 }
 
 export function isTsProjectSourceFile(context: VisitorContext, filePath: string): boolean {


### PR DESCRIPTION
Development versions of TS 4.4 contains a breaking change in the public `matchPatternOrExact` utility function. Specifically, changes were made to add caching to the paths pattern parsing to speed things up.

Relevant commit: https://github.com/microsoft/TypeScript/commit/3ffa245f07c4472ed3015fcb59ea0d2d73432102

Fixing this now due to multiple users using dev builds with issues. More changes may be necessary if logic changes in official release.