### PR TITLE
feat: Add esm support for ts-node register (closes #134)

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+const require = createRequire(fileURLToPath(import.meta.url));
+
+/** @type {import('./dist/register')} */
+const { register } = require('./dist/register');
+
+/** @type {import('ts-node/dist/esm')} */
+import esm  from 'ts-node/dist/esm';
+
+const options = register();
+
+export const {
+  resolve,
+  getFormat,
+  transformSource,
+} = esm.registerAndCreateEsmHooks(options);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "types",
     "README.md",
     "CHANGELOG.md",
-    "register.js"
+    "register.js",
+    "esm.mjs"
   ],
   "devDependencies": {
     "@types/jest": "^26.0.24",

--- a/test/projects/esm/package.json
+++ b/test/projects/esm/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@tests/extras-esm",
+  "version": "0.0.0",
+  "dependencies": {
+    "typescript-transform-paths": "link:../../../"
+  },
+  "type": "module"
+}

--- a/test/projects/esm/src/id.ts
+++ b/test/projects/esm/src/id.ts
@@ -1,0 +1,1 @@
+export const b = null;

--- a/test/projects/esm/src/index.ts
+++ b/test/projects/esm/src/index.ts
@@ -1,0 +1,4 @@
+export * from "#identifier";
+import { b } from "#identifier";
+
+console.log(b);

--- a/test/projects/esm/tsconfig.json
+++ b/test/projects/esm/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "include": [ "src" ],
+
+  "ts-node": {
+    "transpileOnly": true,
+    "require": [ "typescript-transform-paths/register" ],
+  },
+
+  "compilerOptions": {
+    "noEmit": true,
+
+    "rootDir": ".",
+    "module": "ESNext",
+    "target": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "declaration": true,
+
+    "baseUrl": "./src",
+    "paths": {
+      "#identifier": [ "./id.ts" ]
+    },
+
+    "plugins": [
+      {
+        "transform": "typescript-transform-paths"
+      },
+      {
+        "transform": "typescript-transform-paths",
+        "afterDeclarations": true
+      }
+    ]
+  }
+}

--- a/test/tests/extras.test.ts
+++ b/test/tests/extras.test.ts
@@ -10,6 +10,7 @@ import { execSync } from "child_process";
  * ****************************************************************************************************************** */
 
 describe(`Extra Tests`, () => {
+  const esmProjectRoot = ts.normalizePath(path.join(projectsPaths, "esm"));
   const projectRoot = ts.normalizePath(path.join(projectsPaths, "extras"));
   const indexFile = ts.normalizePath(path.join(projectRoot, "src/index.ts"));
   const tsConfigFile = ts.normalizePath(path.join(projectRoot, "tsconfig.json"));
@@ -33,9 +34,20 @@ describe(`Extra Tests`, () => {
       }
     });
 
-    test(`Register script transforms with ts-node`, () => {
-      const res = execSync("ts-node src/index.ts", { cwd: projectRoot }).toString();
-      expect(res).toMatch(/^null($|\r?\n)/);
+    describe(`Register script transforms with ts-node`, () => {
+      test(`CommonJS`, () => {
+        const res = execSync("ts-node src/index.ts", { cwd: projectRoot }).toString();
+        expect(res).toMatch(/^null($|\r?\n)/);
+      });
+
+      // See: https://github.com/LeDDGroup/typescript-transform-paths/issues/134
+      test(`ESM`, () => {
+        const res = execSync(
+          `node --no-warnings --loader typescript-transform-paths/esm --es-module-specifier-resolution=node src/index.ts`,
+          { cwd: esmProjectRoot }
+        ).toString();
+        expect(res).toMatch(/^null($|\r?\n)/);
+      });
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,5 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declaration": true
   }
 }


### PR DESCRIPTION
## Notes

Waiting on upstream PR to export script required for loader to work.

## Related

- https://github.com/LeDDGroup/typescript-transform-paths/issues/134
- https://github.com/TypeStrong/ts-node/pull/1439

## TODO

- Update readme
- Add exception handling to `tsNode.createEsmHooks` not available -> throw `Must use ts-node >=10.2.2` (or relevant version #)