### PR TITLE
fix: More edge cases in ts-node (fixes #163)

### DIFF
--- a/src/utils/ts-helpers.ts
+++ b/src/utils/ts-helpers.ts
@@ -98,7 +98,7 @@ export function getTsNodeRegistrationProperties(tsInstance: typeof ts) {
     : void 0;
 
   const fileNames = pcl?.fileNames || config.fileNames;
-  const compilerOptions = Object.assign(config.options, options.compilerOptions, { outDir: pcl?.options.outDir });
+  const compilerOptions = Object.assign({}, config.options, options.compilerOptions, { outDir: pcl?.options.outDir });
 
   return { compilerOptions, fileNames, tsNodeOptions: options };
 }


### PR DESCRIPTION
Overwriting `Program.compilerOptions` with merged form caused issues in edge cases