### PR TITLE
fix: Don't include 'import type' in JS output

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -106,7 +106,15 @@ export function nodeVisitor(this: VisitorContext, node: ts.Node): ts.Node | unde
    *
    * import ... 'module';
    */
-  if (tsInstance.isImportDeclaration(node) && node.moduleSpecifier && tsInstance.isStringLiteral(node.moduleSpecifier))
+  if (
+    tsInstance.isImportDeclaration(node) &&
+    node.moduleSpecifier &&
+    tsInstance.isStringLiteral(node.moduleSpecifier)
+  ) {
+    if (node.importClause?.isTypeOnly && !this.isDeclarationFile) {
+      return undefined;
+    }
+
     return resolvePathAndUpdateNode(this, node, node.moduleSpecifier.text, (p) => {
       let importClause = node.importClause;
 
@@ -118,6 +126,7 @@ export function nodeVisitor(this: VisitorContext, node: ts.Node): ts.Node | unde
 
       return factory.updateImportDeclaration(node, node.modifiers, importClause, p, node.assertClause);
     });
+  }
 
   /**
    * Update ExportDeclaration

--- a/test/tests/transformer/specific.test.ts
+++ b/test/tests/transformer/specific.test.ts
@@ -112,20 +112,21 @@ describe(`Specific Tests`, () => {
         ) {
           const bases = opt?.base ?? [normalEmit, rootDirsEmit];
           const kinds = (opt?.kind ?? ["dts", "js"]).filter((k) => !skipDts || k !== "dts");
+          const isNot = this.isNot;
 
           let failed: boolean = false;
           const messages: string[] = [];
           for (const base of bases) {
             for (const kind of kinds) {
               const content = base[fileName][kind];
-              const isValid = typeof expected === "string" ? content.indexOf(expected) >= 0 : expected.test(content);
-              if (!isValid) {
-                failed = true;
-                messages.push(
-                  `File: ${fileName}\nKind: ${kind}\nrootDirs: ${base === normalEmit}\n\n` +
-                    `Expected: \`${expected}\`\nReceived:\n\t${content.replace(/(\r?\n)+/g, "$1\t")}`
-                );
-              }
+              const contentContains =
+                typeof expected === "string" ? content.indexOf(expected) >= 0 : expected.test(content);
+              const fileDesc = `File: ${fileName}\nKind: ${kind}\nrootDirs: ${base === normalEmit}\n\n`;
+              const expectDesc = `Expected: ${
+                isNot ? "not to contain" : ""
+              } \`${expected}\`\nReceived:\n\t${content.replace(/(\r?\n)+/g, "$1\t")}`;
+              messages.push(fileDesc + expectDesc);
+              if (!contentContains) failed = true;
             }
           }
 
@@ -182,6 +183,7 @@ describe(`Specific Tests`, () => {
 
     (!skipDts && tsVersion >= 38 ? test : test.skip)(`Import type-only transforms`, () => {
       expect(indexFile).transformedMatches(`import type { A as ATypeOnly } from "./dir/src-file"`, { kind: ["dts"] });
+      expect(indexFile).not.transformedMatches(`import type`, { kind: ["js"] });
     });
 
     test(`Copies comments in async import`, () => {


### PR DESCRIPTION
I ran into an issue where type imports were getting output in Javascript files. For example:
```typescript
import type { A as ATypeOnly } from "./dir/src-file"
```
would be included in the `.js` file created by the Typescript compiler.

This PR excludes all type imports (`node.importClause.isTypeOnly`) from the output unless the output file is a declaration file.