### PR TITLE
getStatementTags | Avoid unnecessary TS debugger statement invocations

### DIFF
--- a/src/utils/resolve-path-update-node.ts
+++ b/src/utils/resolve-path-update-node.ts
@@ -66,7 +66,7 @@ export function resolvePathAndUpdateNode(
     } catch {}
 
     const commentTags = new Map<string, string | undefined>();
-    if(targetNode.pos >= 0) {
+    if (targetNode.pos >= 0) {
       try {
         const trivia = targetNode.getFullText(sourceFile).slice(0, targetNode.getLeadingTriviaWidth(sourceFile));
         const regex = /^\s*\/\/\/?\s*@(transform-path|no-transform-path)(?:[^\S\r\n](.+?))?$/gim;

--- a/src/utils/resolve-path-update-node.ts
+++ b/src/utils/resolve-path-update-node.ts
@@ -66,12 +66,14 @@ export function resolvePathAndUpdateNode(
     } catch {}
 
     const commentTags = new Map<string, string | undefined>();
-    try {
-      const trivia = targetNode.getFullText(sourceFile).slice(0, targetNode.getLeadingTriviaWidth(sourceFile));
-      const regex = /^\s*\/\/\/?\s*@(transform-path|no-transform-path)(?:[^\S\r\n](.+?))?$/gim;
+    if(targetNode.pos >= 0) {
+      try {
+        const trivia = targetNode.getFullText(sourceFile).slice(0, targetNode.getLeadingTriviaWidth(sourceFile));
+        const regex = /^\s*\/\/\/?\s*@(transform-path|no-transform-path)(?:[^\S\r\n](.+?))?$/gim;
 
-      for (let match = regex.exec(trivia); match; match = regex.exec(trivia)) commentTags.set(match[1], match[2]);
-    } catch {}
+        for (let match = regex.exec(trivia); match; match = regex.exec(trivia)) commentTags.set(match[1], match[2]);
+      } catch {}
+    }
 
     const overridePath = findTag("transform-path");
     const shouldSkip = findTag("no-transform-path");


### PR DESCRIPTION
**TL;DR**
Allow running tsc in debug mode when using `typescript-transform-paths` plugin.

**Full Explanation:**
Sometimes it makes sense to run tsc in debug mode. For example in my case, we run tsc + start server in watch mode e.g. `tsc-watch --compiler ttypescript/bin/tsc --onSuccess 'npm start'`. 
And if we run this in a debug session like on VSCode's debug terminal, it means we run both tsc and our sever in debug mode.

The problem is that when typescript throws errors on internal assertions it's also putting a "debugger;" statement right before it throws an error.
![Screenshot 2023-08-27 at 16 33 41](https://github.com/LeDDGroup/typescript-transform-paths/assets/82378873/a34080e9-10b1-4ad3-9099-3b92dcd685bd)

There's a block of code in this package ([typescript-transform-paths](https://github.com/LeDDGroup/typescript-transform-paths)) that wraps such TS errors in a try/catch. That causes our servers to get stuck (repeatedly) on a breakpoint when debugging in watch mode.

So, I've identified the root cause of these cases, and used an if condition to prevent the TS call altogether, instead of the try/catch. 
I left the try/catch though just to be on safe side, cause there might be some other cases which I've missed.

**What is the case that raises the TS error?**
If a NodeObject is in position -1 you can't call getFullText on it.
![Screenshot 2023-08-27 at 16 38 36](https://github.com/LeDDGroup/typescript-transform-paths/assets/82378873/e3080af0-1441-4b8b-985f-81c4cb2016c3)
![Screenshot 2023-08-27 at 16 41 56](https://github.com/LeDDGroup/typescript-transform-paths/assets/82378873/d8f5f28b-51fa-43c9-a25b-a87c466eb3dc)
