### PR TITLE
Fix `getRelativePath` behaviour on case-insensitive filesystems

### DIFF
--- a/src/utils/get-relative-path.ts
+++ b/src/utils/get-relative-path.ts
@@ -69,8 +69,8 @@ function getMatchPortion(from: string, to: string) {
 
 export function getRelativePath(from: string, to: string) {
   try {
-    from = fs.realpathSync.native(from);
     to = fs.realpathSync.native(to);
+    from = fs.realpathSync.native(from);
   } catch {
     if (!getIsFsCaseSensitive()) {
       const matchPortion = getMatchPortion(from, to);


### PR DESCRIPTION
See commit message for explanation. A more elegant solution can likely be devised but this should take care of most cases. Let me know if I should provide more details or a reproducer.