### PR TITLE
ci: remove duplicated checks on gh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,14 @@
 name: Node.js CI
 
-on: [ push, pull_request ]
+on: [push]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 18, 20, 21 ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [18, 20, 21]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
push events on GitHub Action were already running on the pull requests.

Before
![image](https://github.com/user-attachments/assets/8cea4e30-d0a8-4dd8-9e67-f9d8a5c4cfca)

Now

![image](https://github.com/user-attachments/assets/6dbde758-3a92-4d9a-9933-0700df6209b3)
