### PR TITLE
ci: update test workflows to use setup/node action cache and corepack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,34 +24,21 @@ jobs:
         node-version: [18, 20, 21]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Determine Yarn Cache Path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - run: corepack enable
 
-      - uses: actions/cache@v4
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - uses: actions/setup-node@v4
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: "**/yarn.lock"
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
+      - run: yarn install --frozen-lockfile
 
-      - name: Install Packages
-        run: yarn install --frozen-lockfile
-
-      - name: Build
-        run: yarn build
+      - run: yarn build
 
       - name: Test
         run: yarn test --runInBand=false --maxWorkers=2 --workerIdleMemoryLimit=2GB # https://github.com/facebook/jest/issues/11956
         env:
-          CI: true
           NODE_OPTIONS: --max_old_space_size=4096

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,10 @@ jobs:
 
       - run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: yarn
           cache-dependency-path: "**/yarn.lock"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           node-version: 22
           cache: yarn
+          cache-dependency-path: "**/yarn.lock"
       - run: yarn install
       - run: yarn prettier --check .
 


### PR DESCRIPTION
- removed actions/cache in favor of setup/node own caching
- used corepack to select yarn version