### PR TITLE
chore: don't install ts-node on development, just the types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,7 @@ jobs:
       - run: yarn build
 
       - name: Install dependencies for testing
-        run: |
-          yarn install-ttp
-          yarn install
+        run: yarn install
         working-directory: test
 
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,12 @@ jobs:
           cache: yarn
           cache-dependency-path: "**/yarn.lock"
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfiles
 
       - run: yarn build
 
       - name: Install dependencies for testing
-        run: yarn install
+        run: yarn install --frozen-lockfiles
         working-directory: test
 
       - name: Test

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prettier": "^3.3.3",
     "rimraf": "^5.0.10",
     "standard-version": "^9.5.0",
-    "ts-node": "^10.9.2",
+    "@types/ts-node": "npm:ts-node@^10.9.2",
     "ts-patch": "^3.2.1",
     "typescript": "^5.5.4"
   },

--- a/test/package.json
+++ b/test/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "install-ttp": "yarn pack --cwd ../ --filename out.tgz && yarn add -W -D ./out.tgz",
     "test": "jest",
     "prepare": "node prepare.js"
   },
@@ -24,7 +23,7 @@
     "typescript": "^5.5.4",
     "typescript-four-seven": "npm:typescript@4.7.4",
     "typescript-three": "npm:typescript@3.6.5",
-    "typescript-transform-paths": "./out.tgz"
+    "typescript-transform-paths": "file:../"
   },
   "workspaces": {
     "packages": [

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -6299,11 +6299,10 @@ typed-assert@^1.0.8:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
   integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
 
-typescript-transform-paths@./out.tgz:
+"typescript-transform-paths@file:..":
   version "3.4.7"
-  resolved "./out.tgz#ddee49191bf821530720756587d5e666e95bec08"
   dependencies:
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
 
 typescript@^5.5.4:
   version "5.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,25 @@
   resolved "https://registry.yarnpkg.com/ts-expose-internals/-/ts-expose-internals-4.9.5.tgz#c30a77d4c95a423e1c79bbabc95f9b9d00f2fbe3"
   integrity sha512-+T1UsxhFi+hbVyYwHrOUb9tjyhry1iJoiDwDRjZZTiBREb7oE78kRHSqyFv8gZhwZCFFOGZyI66X2gHUFAt8lA==
 
+"@types/ts-node@npm:ts-node@^10.9.2":
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -1476,25 +1495,6 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
-
-ts-node@^10.9.2:
-  version "10.9.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
-  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
-  dependencies:
-    "@cspotcode/source-map-support" "^0.8.0"
-    "@tsconfig/node10" "^1.0.7"
-    "@tsconfig/node12" "^1.0.7"
-    "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.2"
-    acorn "^8.4.1"
-    acorn-walk "^8.1.1"
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
 
 ts-patch@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Reverts the installation workaround introduced in https://github.com/LeDDGroup/typescript-transform-paths/pull/216.

Since we changed the `ts-node` dev dependency to `@types/ts-node`, now it's not resolved by node's `require`