### PR TITLE
ci: generate provenance on npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
         run: npx extract-changelog-release > RELEASE_BODY.md
 
       - name: Publish to NPM
-        run: yarn npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #228 

Example of publishing with --provenance
![image](https://github.com/user-attachments/assets/09ac143b-2330-4515-83af-d5692a001e21)
([gh run](https://github.com/LeDDGroup/typescript-transform-paths/actions/runs/10295350654/job/28494897900))