### PR TITLE
docs: remove all contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FLeDDGroup%2Ftypescript-transform-paths%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/LeDDGroup/typescript-transform-paths/goto?ref=master)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)
 
 Transform compiled source module resolution paths using TypeScript's `paths` config, and/or custom resolution paths.
 


### PR DESCRIPTION
All Contributors hasn't been used in a while, the badge is outdated