### PR TITLE
refact: remove namespaces in favor of modules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ export default [
       "@typescript-eslint/ban-ts-comment": "warn",
       "@typescript-eslint/no-empty-object-type": "warn",
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-namespace": "warn",
+      "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }],
       "@typescript-eslint/no-require-imports": "off",
       "@typescript-eslint/no-unsafe-function-type": "warn",
       "@typescript-eslint/no-unused-vars": "warn",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import tseslint from "typescript-eslint";
 
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
-  { ignores: ["**/dist/", "src/declarations/", "test/projects/"] },
+  { ignores: ["**/dist/", "src/declarations/", "test/projects/", "types/"] },
   { languageOptions: { globals: globals.node } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/harmony/versions/four-seven.ts
+++ b/src/harmony/versions/four-seven.ts
@@ -21,20 +21,18 @@ import { DownSampleTsTypes } from "../utils";
 // region: Mapping
 /* ****************************************************************************************************************** */
 
-export namespace TsFourSeven {
-  export type TypeMap = [
-    [TsCurrentModule.ImportDeclaration, TsFourSevenModule.ImportDeclaration],
-    [TsCurrentModule.Modifier, TsFourSevenModule.Modifier],
-    [TsCurrentModule.ImportClause, TsFourSevenModule.ImportClause],
-    [TsCurrentModule.Expression, TsFourSevenModule.Expression],
-    [TsCurrentModule.AssertClause, TsFourSevenModule.AssertClause],
-    [TsCurrentModule.ExportDeclaration, TsFourSevenModule.ExportDeclaration],
-    [TsCurrentModule.NamedExportBindings, TsFourSevenModule.NamedExportBindings],
-    [TsCurrentModule.ModuleDeclaration, TsFourSevenModule.ModuleDeclaration],
-    [TsCurrentModule.ModuleName, TsFourSevenModule.ModuleName],
-    [TsCurrentModule.ModuleBody, TsFourSevenModule.ModuleBody],
-  ];
-}
+export type TypeMap = [
+  [TsCurrentModule.ImportDeclaration, TsFourSevenModule.ImportDeclaration],
+  [TsCurrentModule.Modifier, TsFourSevenModule.Modifier],
+  [TsCurrentModule.ImportClause, TsFourSevenModule.ImportClause],
+  [TsCurrentModule.Expression, TsFourSevenModule.Expression],
+  [TsCurrentModule.AssertClause, TsFourSevenModule.AssertClause],
+  [TsCurrentModule.ExportDeclaration, TsFourSevenModule.ExportDeclaration],
+  [TsCurrentModule.NamedExportBindings, TsFourSevenModule.NamedExportBindings],
+  [TsCurrentModule.ModuleDeclaration, TsFourSevenModule.ModuleDeclaration],
+  [TsCurrentModule.ModuleName, TsFourSevenModule.ModuleName],
+  [TsCurrentModule.ModuleBody, TsFourSevenModule.ModuleBody],
+];
 
 // endregion
 
@@ -42,83 +40,81 @@ export namespace TsFourSeven {
 // region: Utils
 /* ****************************************************************************************************************** */
 
-export namespace TsFourSeven {
-  export const predicate = ({ tsVersionMajor, tsVersionMinor }: TsTransformPathsContext) =>
-    tsVersionMajor == 4 && tsVersionMinor < 8;
+export const predicate = ({ tsVersionMajor, tsVersionMinor }: TsTransformPathsContext) =>
+  tsVersionMajor == 4 && tsVersionMinor < 8;
 
-  export function handler(context: TsTransformPathsContext, prop: string | symbol) {
-    const factory = context.tsFactory as unknown as TsFourSevenModule.NodeFactory;
+export function handler(context: TsTransformPathsContext, prop: string | symbol) {
+  const factory = context.tsFactory as unknown as TsFourSevenModule.NodeFactory;
 
-    switch (prop) {
-      case "updateImportDeclaration":
-        return function (
-          node: ImportDeclaration,
-          modifiers: readonly Modifier[] | undefined,
-          importClause: ImportClause | undefined,
-          moduleSpecifier: Expression,
-          assertClause: AssertClause | undefined,
-        ) {
-          const [dsNode, dsImportClause, dsModuleSpecifier, dsAssertClause] = downSample(
-            node,
-            importClause,
-            moduleSpecifier,
-            assertClause,
-          );
+  switch (prop) {
+    case "updateImportDeclaration":
+      return function (
+        node: ImportDeclaration,
+        modifiers: readonly Modifier[] | undefined,
+        importClause: ImportClause | undefined,
+        moduleSpecifier: Expression,
+        assertClause: AssertClause | undefined,
+      ) {
+        const [dsNode, dsImportClause, dsModuleSpecifier, dsAssertClause] = downSample(
+          node,
+          importClause,
+          moduleSpecifier,
+          assertClause,
+        );
 
-          return factory.updateImportDeclaration(
-            dsNode,
-            dsNode.decorators,
-            dsNode.modifiers,
-            dsImportClause,
-            dsModuleSpecifier,
-            dsAssertClause,
-          );
-        };
-      case "updateExportDeclaration":
-        return function (
-          node: ExportDeclaration,
-          modifiers: readonly Modifier[] | undefined,
-          isTypeOnly: boolean,
-          exportClause: NamedExportBindings | undefined,
-          moduleSpecifier: Expression | undefined,
-          assertClause: AssertClause | undefined,
-        ) {
-          const [dsNode, dsExportClause, dsModuleSpecifier, dsAssertClause] = downSample(
-            node,
-            exportClause,
-            moduleSpecifier,
-            assertClause,
-          );
+        return factory.updateImportDeclaration(
+          dsNode,
+          dsNode.decorators,
+          dsNode.modifiers,
+          dsImportClause,
+          dsModuleSpecifier,
+          dsAssertClause,
+        );
+      };
+    case "updateExportDeclaration":
+      return function (
+        node: ExportDeclaration,
+        modifiers: readonly Modifier[] | undefined,
+        isTypeOnly: boolean,
+        exportClause: NamedExportBindings | undefined,
+        moduleSpecifier: Expression | undefined,
+        assertClause: AssertClause | undefined,
+      ) {
+        const [dsNode, dsExportClause, dsModuleSpecifier, dsAssertClause] = downSample(
+          node,
+          exportClause,
+          moduleSpecifier,
+          assertClause,
+        );
 
-          return factory.updateExportDeclaration(
-            dsNode,
-            dsNode.decorators,
-            dsNode.modifiers,
-            isTypeOnly,
-            dsExportClause,
-            dsModuleSpecifier,
-            dsAssertClause,
-          );
-        };
-      case "updateModuleDeclaration":
-        return function (
-          node: ModuleDeclaration,
-          modifiers: readonly Modifier[] | undefined,
-          name: ModuleName,
-          body: ModuleBody | undefined,
-        ) {
-          const [dsNode, dsName, dsBody] = downSample(node, name, body);
+        return factory.updateExportDeclaration(
+          dsNode,
+          dsNode.decorators,
+          dsNode.modifiers,
+          isTypeOnly,
+          dsExportClause,
+          dsModuleSpecifier,
+          dsAssertClause,
+        );
+      };
+    case "updateModuleDeclaration":
+      return function (
+        node: ModuleDeclaration,
+        modifiers: readonly Modifier[] | undefined,
+        name: ModuleName,
+        body: ModuleBody | undefined,
+      ) {
+        const [dsNode, dsName, dsBody] = downSample(node, name, body);
 
-          return factory.updateModuleDeclaration(dsNode, dsNode.decorators, dsNode.modifiers, dsName, dsBody);
-        };
-      default:
-        return (...args: any) => (<any>factory)[prop](...args);
-    }
+        return factory.updateModuleDeclaration(dsNode, dsNode.decorators, dsNode.modifiers, dsName, dsBody);
+      };
+    default:
+      return (...args: any) => (<any>factory)[prop](...args);
   }
+}
 
-  export function downSample<T extends [...unknown[]]>(...args: T): DownSampleTsTypes<TypeMap, T> {
-    return <any>args;
-  }
+export function downSample<T extends [...unknown[]]>(...args: T): DownSampleTsTypes<TypeMap, T> {
+  return <any>args;
 }
 
 // endregion

--- a/src/harmony/versions/index.ts
+++ b/src/harmony/versions/index.ts
@@ -1,2 +1,2 @@
-export * from "./three-eight";
-export * from "./four-seven";
+export * as TsThreeEight from "./three-eight";
+export * as TsFourSeven from "./four-seven";

--- a/src/harmony/versions/three-eight.ts
+++ b/src/harmony/versions/three-eight.ts
@@ -18,7 +18,7 @@ import TsCurrentModule, {
   NamedImportBindings,
   TypeNode,
 } from "typescript";
-import * as TsThreeEightModule from "../../declarations/typescript3";
+import type TsThreeEightModule from "../../declarations/typescript3";
 import { TsTransformPathsContext } from "../../types";
 import { DownSampleTsTypes } from "../utils";
 
@@ -26,34 +26,32 @@ import { DownSampleTsTypes } from "../utils";
 // region: Mapping
 /* ****************************************************************************************************************** */
 
-export namespace TsThreeEight {
-  export type TypeMap = [
-    [TsCurrentModule.SourceFile, TsThreeEightModule.SourceFile],
-    [TsCurrentModule.StringLiteral, TsThreeEightModule.StringLiteral],
-    [TsCurrentModule.CompilerOptions, TsThreeEightModule.CompilerOptions],
-    [TsCurrentModule.EmitResolver, TsThreeEightModule.EmitResolver],
-    [TsCurrentModule.CallExpression, TsThreeEightModule.CallExpression],
-    [TsCurrentModule.ExternalModuleReference, TsThreeEightModule.ExternalModuleReference],
-    [TsCurrentModule.LiteralTypeNode, TsThreeEightModule.LiteralTypeNode],
-    [TsCurrentModule.ExternalModuleReference, TsThreeEightModule.ExternalModuleReference],
-    [TsCurrentModule.ImportTypeNode, TsThreeEightModule.ImportTypeNode],
-    [TsCurrentModule.EntityName, TsThreeEightModule.EntityName],
-    [TsCurrentModule.TypeNode, TsThreeEightModule.TypeNode],
-    [readonly TsCurrentModule.TypeNode[], readonly TsThreeEightModule.TypeNode[]],
-    [TsCurrentModule.LiteralTypeNode, TsThreeEightModule.LiteralTypeNode],
-    [TsCurrentModule.ImportDeclaration, TsThreeEightModule.ImportDeclaration],
-    [TsCurrentModule.ImportClause, TsThreeEightModule.ImportClause],
-    [TsCurrentModule.Identifier, TsThreeEightModule.Identifier],
-    [TsCurrentModule.NamedImportBindings, TsThreeEightModule.NamedImportBindings],
-    [TsCurrentModule.ImportDeclaration, TsThreeEightModule.ImportDeclaration],
-    [TsCurrentModule.ExportDeclaration, TsThreeEightModule.ExportDeclaration],
-    [TsCurrentModule.ModuleDeclaration, TsThreeEightModule.ModuleDeclaration],
-    [TsCurrentModule.Expression, TsThreeEightModule.Expression],
-    [TsCurrentModule.ModuleBody, TsThreeEightModule.ModuleBody],
-    [TsCurrentModule.ModuleName, TsThreeEightModule.ModuleName],
-    [TsCurrentModule.ExportDeclaration["exportClause"], TsThreeEightModule.ExportDeclaration["exportClause"]],
-  ];
-}
+export type TypeMap = [
+  [TsCurrentModule.SourceFile, TsThreeEightModule.SourceFile],
+  [TsCurrentModule.StringLiteral, TsThreeEightModule.StringLiteral],
+  [TsCurrentModule.CompilerOptions, TsThreeEightModule.CompilerOptions],
+  [TsCurrentModule.EmitResolver, TsThreeEightModule.EmitResolver],
+  [TsCurrentModule.CallExpression, TsThreeEightModule.CallExpression],
+  [TsCurrentModule.ExternalModuleReference, TsThreeEightModule.ExternalModuleReference],
+  [TsCurrentModule.LiteralTypeNode, TsThreeEightModule.LiteralTypeNode],
+  [TsCurrentModule.ExternalModuleReference, TsThreeEightModule.ExternalModuleReference],
+  [TsCurrentModule.ImportTypeNode, TsThreeEightModule.ImportTypeNode],
+  [TsCurrentModule.EntityName, TsThreeEightModule.EntityName],
+  [TsCurrentModule.TypeNode, TsThreeEightModule.TypeNode],
+  [readonly TsCurrentModule.TypeNode[], readonly TsThreeEightModule.TypeNode[]],
+  [TsCurrentModule.LiteralTypeNode, TsThreeEightModule.LiteralTypeNode],
+  [TsCurrentModule.ImportDeclaration, TsThreeEightModule.ImportDeclaration],
+  [TsCurrentModule.ImportClause, TsThreeEightModule.ImportClause],
+  [TsCurrentModule.Identifier, TsThreeEightModule.Identifier],
+  [TsCurrentModule.NamedImportBindings, TsThreeEightModule.NamedImportBindings],
+  [TsCurrentModule.ImportDeclaration, TsThreeEightModule.ImportDeclaration],
+  [TsCurrentModule.ExportDeclaration, TsThreeEightModule.ExportDeclaration],
+  [TsCurrentModule.ModuleDeclaration, TsThreeEightModule.ModuleDeclaration],
+  [TsCurrentModule.Expression, TsThreeEightModule.Expression],
+  [TsCurrentModule.ModuleBody, TsThreeEightModule.ModuleBody],
+  [TsCurrentModule.ModuleName, TsThreeEightModule.ModuleName],
+  [TsCurrentModule.ExportDeclaration["exportClause"], TsThreeEightModule.ExportDeclaration["exportClause"]],
+];
 
 // endregion
 
@@ -61,97 +59,90 @@ export namespace TsThreeEight {
 // region: Utils
 /* ****************************************************************************************************************** */
 
-export namespace TsThreeEight {
-  export const predicate = (context: TsTransformPathsContext) => context.tsVersionMajor < 4;
+export const predicate = (context: TsTransformPathsContext) => context.tsVersionMajor < 4;
 
-  export function handler(context: TsTransformPathsContext, prop: string | symbol) {
-    const ts = context.tsInstance as unknown as typeof TsThreeEightModule;
+export function handler(context: TsTransformPathsContext, prop: string | symbol) {
+  const ts = context.tsInstance as unknown as typeof TsThreeEightModule;
 
-    switch (prop) {
-      case "updateCallExpression":
-        return (...args: any) => ts.updateCall.apply(void 0, args);
-      case "updateImportClause":
-        return function (
-          node: ImportClause,
-          isTypeOnly: boolean,
-          name: Identifier | undefined,
-          namedBindings: NamedImportBindings | undefined,
-        ) {
-          return ts.updateImportClause.apply(void 0, downSample(node, name, namedBindings));
-        };
-      case "updateImportDeclaration":
-        return function (
-          node: ImportDeclaration,
-          modifiers: readonly Modifier[] | undefined,
-          importClause: ImportClause | undefined,
-          moduleSpecifier: Expression,
-        ) {
-          const [dsNode, dsImportClause, dsModuleSpecifier] = downSample(node, importClause, moduleSpecifier);
+  switch (prop) {
+    case "updateCallExpression":
+      return (...args: any) => ts.updateCall.apply(void 0, args);
+    case "updateImportClause":
+      return function (
+        node: ImportClause,
+        isTypeOnly: boolean,
+        name: Identifier | undefined,
+        namedBindings: NamedImportBindings | undefined,
+      ) {
+        return ts.updateImportClause.apply(void 0, downSample(node, name, namedBindings));
+      };
+    case "updateImportDeclaration":
+      return function (
+        node: ImportDeclaration,
+        modifiers: readonly Modifier[] | undefined,
+        importClause: ImportClause | undefined,
+        moduleSpecifier: Expression,
+      ) {
+        const [dsNode, dsImportClause, dsModuleSpecifier] = downSample(node, importClause, moduleSpecifier);
 
-          return ts.updateImportDeclaration(
-            dsNode,
-            dsNode.decorators,
-            dsNode.modifiers,
-            dsImportClause,
-            dsModuleSpecifier,
-          );
-        };
-      case "updateExportDeclaration":
-        return function (
-          node: ExportDeclaration,
-          modifiers: readonly Modifier[] | undefined,
-          isTypeOnly: boolean,
-          exportClause: NamedExportBindings | undefined,
-          moduleSpecifier: Expression | undefined,
-        ) {
-          const [dsNode, dsModuleSpecifier, dsExportClause] = downSample(node, moduleSpecifier, exportClause);
-          return ts.updateExportDeclaration(
-            dsNode,
-            dsNode.decorators,
-            dsNode.modifiers,
-            dsExportClause,
-            dsModuleSpecifier,
-            // @ts-ignore - This was added in later versions of 3.x
-            dsNode.isTypeOnly,
-          );
-        };
-      case "updateModuleDeclaration":
-        return function (
-          node: ModuleDeclaration,
-          modifiers: readonly Modifier[] | undefined,
-          name: ModuleName,
-          body: ModuleBody | undefined,
-        ) {
-          const [dsNode, dsName, dsBody] = downSample(node, name, body);
+        return ts.updateImportDeclaration(
+          dsNode,
+          dsNode.decorators,
+          dsNode.modifiers,
+          dsImportClause,
+          dsModuleSpecifier,
+        );
+      };
+    case "updateExportDeclaration":
+      return function (
+        node: ExportDeclaration,
+        modifiers: readonly Modifier[] | undefined,
+        isTypeOnly: boolean,
+        exportClause: NamedExportBindings | undefined,
+        moduleSpecifier: Expression | undefined,
+      ) {
+        const [dsNode, dsModuleSpecifier, dsExportClause] = downSample(node, moduleSpecifier, exportClause);
+        return ts.updateExportDeclaration(
+          dsNode,
+          dsNode.decorators,
+          dsNode.modifiers,
+          dsExportClause,
+          dsModuleSpecifier,
+          // @ts-ignore - This was added in later versions of 3.x
+          dsNode.isTypeOnly,
+        );
+      };
+    case "updateModuleDeclaration":
+      return function (
+        node: ModuleDeclaration,
+        modifiers: readonly Modifier[] | undefined,
+        name: ModuleName,
+        body: ModuleBody | undefined,
+      ) {
+        const [dsNode, dsName, dsBody] = downSample(node, name, body);
 
-          return ts.updateModuleDeclaration(dsNode, dsNode.decorators, dsNode.modifiers, dsName, dsBody);
-        };
-      case "updateImportTypeNode":
-        return function (
-          node: ImportTypeNode,
-          argument: TypeNode,
-          assertions: ImportTypeAssertionContainer | undefined,
-          qualifier: EntityName | undefined,
-          typeArguments: readonly TypeNode[] | undefined,
-          isTypeOf?: boolean,
-        ) {
-          const [dsNode, dsArgument, dsQualifier, dsTypeArguments] = downSample(
-            node,
-            argument,
-            qualifier,
-            typeArguments,
-          );
+        return ts.updateModuleDeclaration(dsNode, dsNode.decorators, dsNode.modifiers, dsName, dsBody);
+      };
+    case "updateImportTypeNode":
+      return function (
+        node: ImportTypeNode,
+        argument: TypeNode,
+        assertions: ImportTypeAssertionContainer | undefined,
+        qualifier: EntityName | undefined,
+        typeArguments: readonly TypeNode[] | undefined,
+        isTypeOf?: boolean,
+      ) {
+        const [dsNode, dsArgument, dsQualifier, dsTypeArguments] = downSample(node, argument, qualifier, typeArguments);
 
-          return ts.updateImportTypeNode(dsNode, dsArgument, dsQualifier, dsTypeArguments, isTypeOf);
-        };
-      default:
-        return (...args: any) => (<any>ts)[prop](...args);
-    }
+        return ts.updateImportTypeNode(dsNode, dsArgument, dsQualifier, dsTypeArguments, isTypeOf);
+      };
+    default:
+      return (...args: any) => (<any>ts)[prop](...args);
   }
+}
 
-  export function downSample<T extends [...unknown[]]>(...args: T): DownSampleTsTypes<TypeMap, T> {
-    return <any>args;
-  }
+export function downSample<T extends [...unknown[]]>(...args: T): DownSampleTsTypes<TypeMap, T> {
+  return <any>args;
 }
 
 // endregion

--- a/src/register.ts
+++ b/src/register.ts
@@ -89,33 +89,31 @@ export function register(): TSNode.RegisterOptions | undefined {
   return registerOptions;
 }
 
-export namespace register {
-  export function initialize(): {
-    tsNode: typeof TSNode;
-    instanceSymbol: typeof REGISTER_INSTANCE;
-    tsNodeInstance: TSNode.Service;
-  } {
-    let tsNode: typeof TSNode;
-    try {
-      tsNode = require("ts-node");
-    } catch {
-      throw new Error(
-        `Cannot resolve ts-node. Make sure ts-node is installed before using typescript-transform-paths/register`,
-      );
-    }
-
-    const instanceSymbol: typeof REGISTER_INSTANCE = tsNode["REGISTER_INSTANCE"];
-
-    let tsNodeInstance = global.process[instanceSymbol];
-    if (!tsNodeInstance) {
-      tsNode.register(); // Register initially
-      tsNodeInstance = global.process[instanceSymbol];
-    }
-    if (!tsNodeInstance) throw new Error(`Could not register ts-node instance!`);
-
-    return { tsNode, instanceSymbol, tsNodeInstance };
+register.initialize = function initialize(): {
+  tsNode: typeof TSNode;
+  instanceSymbol: typeof REGISTER_INSTANCE;
+  tsNodeInstance: TSNode.Service;
+} {
+  let tsNode: typeof TSNode;
+  try {
+    tsNode = require("ts-node");
+  } catch {
+    throw new Error(
+      `Cannot resolve ts-node. Make sure ts-node is installed before using typescript-transform-paths/register`,
+    );
   }
-}
+
+  const instanceSymbol: typeof REGISTER_INSTANCE = tsNode["REGISTER_INSTANCE"];
+
+  let tsNodeInstance = global.process[instanceSymbol];
+  if (!tsNodeInstance) {
+    tsNode.register(); // Register initially
+    tsNodeInstance = global.process[instanceSymbol];
+  }
+  if (!tsNodeInstance) throw new Error(`Could not register ts-node instance!`);
+
+  return { tsNode, instanceSymbol, tsNodeInstance };
+};
 
 export default register;
 


### PR DESCRIPTION
Removing typescript only namespaces in favor of using modules per typescript recommendation. This should produce more compliant code and output more readable javascript

[From typescript](https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html#using-modules)

> It is also worth noting that, for Node.js applications, modules are the default and we recommended modules over namespaces in modern code.

> Starting with ECMAScript 2015, modules are native part of the language, and should be supported by all compliant engine implementations. Thus, for new projects modules would be the recommended code organization mechanism.

See [the diff](https://github.com/LeDDGroup/typescript-transform-paths/pull/236/files?diff=unified&w=1) without whitespace changes