### PR TITLE
refact: fix no-require-imports eslint warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,9 +17,15 @@ export default [
     },
   },
   {
+    // overrides for cjs files
+    files: ["*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+  {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-require-imports": "off",
       "@typescript-eslint/no-unused-vars": "warn",
     },
   },

--- a/src/register.ts
+++ b/src/register.ts
@@ -96,6 +96,7 @@ register.initialize = function initialize(): {
 } {
   let tsNode: typeof TSNode;
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     tsNode = require("ts-node");
   } catch {
     throw new Error(

--- a/src/utils/ts-helpers.ts
+++ b/src/utils/ts-helpers.ts
@@ -83,6 +83,7 @@ export function createSyntheticEmitHost(
 export function getTsNodeRegistrationProperties(tsInstance: typeof ts) {
   let tsNodeSymbol: typeof REGISTER_INSTANCE;
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     tsNodeSymbol = require("ts-node")?.["REGISTER_INSTANCE"];
   } catch {
     return undefined;

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,15 +1,13 @@
 import ts from "typescript";
-import TypeScriptThree from "typescript-three";
-import TypeScriptFourSeven from "typescript-four-seven";
+import tsThree from "typescript-three";
+import tsFourSeven from "typescript-four-seven";
 import path from "path";
 
 /* ****************************************************************************************************************** */
 // region: TS Instances
 /* ****************************************************************************************************************** */
 
-export { ts };
-export const tsThree: typeof TypeScriptThree = require("typescript-three");
-export const tsFourSeven: typeof TypeScriptFourSeven = require("typescript-four-seven");
+export { ts, tsThree, tsFourSeven };
 
 // endregion
 

--- a/test/tests/extras.test.ts
+++ b/test/tests/extras.test.ts
@@ -1,4 +1,4 @@
-import { createTsProgram, getEmitResultFromProgram } from "../utils";
+import { createTsProgram, getEmitResultFromProgram, ModuleNotFoundError } from "../utils";
 import { projectsPaths } from "../config";
 import path from "path";
 import ts from "typescript";
@@ -18,7 +18,13 @@ describe(`Extra Tests`, () => {
   describe(`Built Tests`, () => {
     // see: https://github.com/LeDDGroup/typescript-transform-paths/issues/130
     test(`Transformer works without ts-node being present`, () => {
-      jest.doMock("ts-node", () => ({}), { virtual: true });
+      jest.doMock(
+        "ts-node",
+        () => {
+          throw new ModuleNotFoundError("ts-node");
+        },
+        { virtual: true },
+      );
       try {
         const program = createTsProgram({ tsInstance: ts, tsConfigFile }, config.builtTransformerPath);
         const res = getEmitResultFromProgram(program);

--- a/test/tests/extras.test.ts
+++ b/test/tests/extras.test.ts
@@ -18,13 +18,7 @@ describe(`Extra Tests`, () => {
   describe(`Built Tests`, () => {
     // see: https://github.com/LeDDGroup/typescript-transform-paths/issues/130
     test(`Transformer works without ts-node being present`, () => {
-      jest.doMock(
-        "ts-node",
-        () => {
-          require("sdf0s39rf3333d@fake-module");
-        },
-        { virtual: true },
-      );
+      jest.doMock("ts-node", () => ({}), { virtual: true });
       try {
         const program = createTsProgram({ tsInstance: ts, tsConfigFile }, config.builtTransformerPath);
         const res = getEmitResultFromProgram(program);

--- a/test/tests/register.test.ts
+++ b/test/tests/register.test.ts
@@ -4,6 +4,7 @@ import * as tsNode from "ts-node";
 import * as transformerModule from "typescript-transform-paths/dist/transformer";
 import { REGISTER_INSTANCE } from "ts-node";
 import { CustomTransformers, PluginImport, Program } from "typescript";
+import { ModuleNotFoundError } from "../utils";
 
 /* ****************************************************************************************************************** *
  * Config
@@ -88,7 +89,13 @@ describe(`Register script`, () => {
 
   describe(`Register`, () => {
     test(`Throws without ts-node`, () => {
-      jest.doMock("ts-node", () => ({}), { virtual: true });
+      jest.doMock(
+        "ts-node",
+        () => {
+          throw new ModuleNotFoundError("ts-node");
+        },
+        { virtual: true },
+      );
       expect(() => register()).toThrow(`Cannot resolve ts-node`);
       jest.dontMock("ts-node");
     });

--- a/test/tests/register.test.ts
+++ b/test/tests/register.test.ts
@@ -88,13 +88,7 @@ describe(`Register script`, () => {
 
   describe(`Register`, () => {
     test(`Throws without ts-node`, () => {
-      jest.doMock(
-        "ts-node",
-        () => {
-          require("sdf0s39rf3333d@fake-module");
-        },
-        { virtual: true },
-      );
+      jest.doMock("ts-node", () => ({}), { virtual: true });
       expect(() => register()).toThrow(`Cannot resolve ts-node`);
       jest.dontMock("ts-node");
     });

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -185,6 +185,7 @@ export function getTsNodeEmitResult(
   const compiler = tsNode.create({
     transpileOnly: true,
     transformers: {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       before: [tstpTransform(void 0, pluginConfig, <any>{ ts: require(tsSpecifier) })],
     },
     project: pcl.options.configFilePath,

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./helpers";
+export * from "./module-not-found-error";

--- a/test/utils/module-not-found-error.ts
+++ b/test/utils/module-not-found-error.ts
@@ -1,0 +1,8 @@
+/** Mimicks a module not found nodejs error, see https://nodejs.org/docs/v20.16.0/api/errors.html */
+export class ModuleNotFoundError extends Error {
+  code = "MODULE_NOT_FOUND";
+
+  constructor(packageName: string, options?: ErrorOptions) {
+    super(`Uncaught Error: Cannot find module '${packageName}'`, options);
+  }
+}


### PR DESCRIPTION
Removed `require`s in favor of `import`. Kept it in a couple of places where using import was not possible.

Also replaced the `require('fake-module')` in favor of simulating a nodejs MODULE_NOT_FOUND error for testing