### PR TITLE
Fix #266: restore in TS 5.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/eslint": "^9",
     "@types/minimatch": "^5.1.2",
     "@types/node": "^22.5.2",
-    "@types/ts-expose-internals": "npm:ts-expose-internals@4.9.5",
+    "@types/ts-expose-internals": "npm:ts-expose-internals@5.6.2",
     "@types/ts-node": "npm:ts-node@^10.9.2",
     "@types/typescript-3": "npm:typescript@3.x",
     "@types/typescript-4.7": "npm:typescript@4.7.x",
@@ -76,7 +76,7 @@
     "prettier": "^3.3.3",
     "prettier-plugin-jsdoc": "^1.3.0",
     "ts-patch": "^3.2.1",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.2",
     "typescript-eslint": "^8.3.0"
   },
   "peerDependencies": {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -135,9 +135,9 @@ export default function transformer(
         ...tsTransformPathsContext,
         sourceFile,
         isDeclarationFile: sourceFile.isDeclarationFile,
-        originalSourceFile: (<typeof ts>tsInstance).getOriginalSourceFile(sourceFile),
+        originalSourceFile: tsInstance.getSourceFileOfNode(sourceFile),
         getVisitor() {
-          return nodeVisitor.bind(this);
+          return nodeVisitor.bind(this) as (node: ts.Node) => ts.VisitResult<ts.Node>;
         },
         factory: createHarmonyFactory(tsTransformPathsContext),
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,10 +296,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ts-expose-internals@npm:ts-expose-internals@4.9.5":
-  version: 4.9.5
-  resolution: "ts-expose-internals@npm:4.9.5"
-  checksum: 10c0/3f5b24f30c1f31a982f2a93b72de18c70da3e4c26d90afdc9428d00c7eef42d91beac7a0fa564f8af815c044ae26ca6da4d9e3aea21a2f479511397ead4d0c8e
+"@types/ts-expose-internals@npm:ts-expose-internals@5.6.2":
+  version: 5.6.2
+  resolution: "ts-expose-internals@npm:5.6.2"
+  checksum: 10c0/2f53e67b7554cc9003879734e24b536459ade19927c510f8f4835e10b7ef563948da91a8f8dc4a78498e97dbc430f022c6875dca66ab5bafd953d52f03c4977f
   languageName: node
   linkType: hard
 
@@ -2993,7 +2993,7 @@ __metadata:
     "@types/eslint": "npm:^9"
     "@types/minimatch": "npm:^5.1.2"
     "@types/node": "npm:^22.5.2"
-    "@types/ts-expose-internals": "npm:ts-expose-internals@4.9.5"
+    "@types/ts-expose-internals": "npm:ts-expose-internals@5.6.2"
     "@types/ts-node": "npm:ts-node@^10.9.2"
     "@types/typescript-3": "npm:typescript@3.x"
     "@types/typescript-4.7": "npm:typescript@4.7.x"
@@ -3004,30 +3004,30 @@ __metadata:
     prettier: "npm:^3.3.3"
     prettier-plugin-jsdoc: "npm:^1.3.0"
     ts-patch: "npm:^3.2.1"
-    typescript: "npm:^5.5.4"
+    typescript: "npm:^5.6.2"
     typescript-eslint: "npm:^8.3.0"
   peerDependencies:
     typescript: ">=3.6.5"
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^5.5.4":
-  version: 5.5.4
-  resolution: "typescript@npm:5.5.4"
+"typescript@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "typescript@npm:5.6.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+  checksum: 10c0/3ed8297a8c7c56b7fec282532503d1ac795239d06e7c4966b42d4330c6cf433a170b53bcf93a130a7f14ccc5235de5560df4f1045eb7f3550b46ebed16d3c5e5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
-  version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+"typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>":
+  version: 5.6.2
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=74658d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
+  checksum: 10c0/e6c1662e4852e22fe4bbdca471dca3e3edc74f6f1df043135c44a18a7902037023ccb0abdfb754595ca9028df8920f2f8492c00fc3cbb4309079aae8b7de71cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Failed to compile `transform-typescript-paths` due to many TypeScript compilation errors. Therefore, don't know whether this PR is valid or not. Hope your strict your review @nonara.

Instead, tested on my project manually editing the JS file in the `node_modules/typescript-transform-paths` directory.