### PR TITLE
chore(deps): downgrade minimatch from 10.0.1 to 9.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "typescript": ">=3.6.5"
   },
   "dependencies": {
-    "minimatch": "^10.0.1"
+    "minimatch": "^9.0.5"
   },
   "prettier": {
     "plugins": [

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -6579,15 +6579,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -6606,7 +6597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -9243,7 +9234,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "typescript-transform-paths@portal:../::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    minimatch: "npm:^10.0.1"
+    minimatch: "npm:^9.0.5"
   peerDependencies:
     typescript: ">=3.6.5"
   languageName: node

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,15 +2151,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -2169,7 +2160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -3000,7 +2991,7 @@ __metadata:
     changelogen: "npm:^0.5.5"
     eslint: "npm:9.x"
     globals: "npm:^15.9.0"
-    minimatch: "npm:^10.0.1"
+    minimatch: "npm:^9.0.5"
     prettier: "npm:^3.3.3"
     prettier-plugin-jsdoc: "npm:^1.3.0"
     ts-patch: "npm:^3.2.1"


### PR DESCRIPTION
https://github.com/LeDDGroup/typescript-transform-paths/issues/271

downgrade the minimatch dependency from 10.0.1 to 9.0.5 to remove a node 20 dependency.