### PR TITLE
fix: restore typescript 5.6 compatibility

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -135,7 +135,9 @@ export default function transformer(
         ...tsTransformPathsContext,
         sourceFile,
         isDeclarationFile: sourceFile.isDeclarationFile,
-        originalSourceFile: (<typeof ts>tsInstance).getOriginalSourceFile(sourceFile),
+        originalSourceFile: (<typeof ts>tsInstance).getSourceFileOfNode
+          ? (<typeof ts>tsInstance).getSourceFileOfNode(sourceFile)
+          : (<typeof ts>tsInstance).getOriginalSourceFile(sourceFile),
         getVisitor() {
           return nodeVisitor.bind(this);
         },

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -135,9 +135,7 @@ export default function transformer(
         ...tsTransformPathsContext,
         sourceFile,
         isDeclarationFile: sourceFile.isDeclarationFile,
-        originalSourceFile: (<typeof ts>tsInstance).getSourceFileOfNode
-          ? (<typeof ts>tsInstance).getSourceFileOfNode(sourceFile)
-          : (<typeof ts>tsInstance).getOriginalSourceFile(sourceFile),
+        originalSourceFile: ts.getParseTreeNode(sourceFile, ts.isSourceFile) || sourceFile,
         getVisitor() {
           return nodeVisitor.bind(this);
         },

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,11 +1,13 @@
 import ts from "typescript";
 import tsThree from "typescript-3";
 import tsFourSeven from "typescript-4.7";
+import tsFiveFive from "typescript-5.5";
 import path from "node:path";
 
 export const tsModules = <const>[
   ["3.6.5", tsThree, "typescript-3"],
   ["4.7.4", tsFourSeven, "typescript-4.7"],
+  ["5.5.4", tsFiveFive, "typescript-5.5"],
   ["Latest", ts, "typescript"],
 ];
 

--- a/test/config.ts
+++ b/test/config.ts
@@ -2,12 +2,14 @@ import ts from "typescript";
 import tsThree from "typescript-3";
 import tsFourSeven from "typescript-4.7";
 import tsFiveFive from "typescript-5.5";
+import tsFiveSix from "typescript-5.6";
 import path from "node:path";
 
 export const tsModules = <const>[
   ["3.6.5", tsThree, "typescript-3"],
   ["4.7.4", tsFourSeven, "typescript-4.7"],
   ["5.5.4", tsFiveFive, "typescript-5.5"],
+  ["5.6.3", tsFiveSix, "typescript-5.6"],
   ["Latest", ts, "typescript"],
 ];
 

--- a/test/package.json
+++ b/test/package.json
@@ -21,7 +21,7 @@
     "ts-patch": "^3.2.1",
     "tsp1": "npm:ts-patch@1.*.*",
     "tsp2": "npm:ts-patch@2.*.*",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.3",
     "typescript-3": "npm:typescript@3.6.5",
     "typescript-4.7": "npm:typescript@4.7.4",
     "typescript-5.5": "npm:typescript@5.5.4",

--- a/test/package.json
+++ b/test/package.json
@@ -25,6 +25,7 @@
     "typescript-3": "npm:typescript@3.6.5",
     "typescript-4.7": "npm:typescript@4.7.4",
     "typescript-5.5": "npm:typescript@5.5.4",
+    "typescript-5.6": "npm:typescript@5.6.3",
     "typescript-transform-paths": "portal:../"
   },
   "workspaces": [

--- a/test/package.json
+++ b/test/package.json
@@ -24,6 +24,7 @@
     "typescript": "^5.5.4",
     "typescript-3": "npm:typescript@3.6.5",
     "typescript-4.7": "npm:typescript@4.7.4",
+    "typescript-5.5": "npm:typescript@5.5.4",
     "typescript-transform-paths": "portal:../"
   },
   "workspaces": [

--- a/test/prepare.mjs
+++ b/test/prepare.mjs
@@ -30,6 +30,7 @@ function patchTsModules() {
 
   patchTypescript("typescript-3", patch1);
   patchTypescript("typescript-4.7", patch2);
+  patchTypescript("typescript-5.5", patch);
   patchTypescript("typescript", patch);
 }
 

--- a/test/prepare.mjs
+++ b/test/prepare.mjs
@@ -31,6 +31,7 @@ function patchTsModules() {
   patchTypescript("typescript-3", patch1);
   patchTypescript("typescript-4.7", patch2);
   patchTypescript("typescript-5.5", patch);
+  patchTypescript("typescript-5.6", patch);
   patchTypescript("typescript", patch);
 }
 

--- a/test/tests/extras.test.ts
+++ b/test/tests/extras.test.ts
@@ -34,14 +34,20 @@ describe(`Extra Tests`, () => {
     });
 
     describe(`ts-node register script`, () => {
+      /** Yarn sometimes outputs bold text, which makes these tests flakey */
+      function stripAnsi(str: string) {
+        // eslint-disable-next-line no-control-regex
+        return str.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+      }
+
       test(`Works with --transpileOnly`, () => {
         const res = execSync("yarn g:ts-node --transpileOnly src/index.ts", { cwd: projectRoot }).toString();
-        expect(res).toMatch(/^null($|\r?\n)/m);
+        expect(stripAnsi(res.trim())).toEqual("null");
       });
 
       test(`Works with --typeCheck`, () => {
         const res = execSync("yarn g:ts-node --typeCheck src/index.ts", { cwd: projectRoot }).toString();
-        expect(res).toMatch(/^null($|\r?\n)/);
+        expect(stripAnsi(res.trim())).toEqual("null");
       });
     });
   });

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -8073,6 +8073,7 @@ __metadata:
     typescript-3: "npm:typescript@3.6.5"
     typescript-4.7: "npm:typescript@4.7.4"
     typescript-5.5: "npm:typescript@5.5.4"
+    typescript-5.6: "npm:typescript@5.6.3"
     typescript-transform-paths: "portal:../"
   languageName: unknown
   linkType: soft
@@ -9238,6 +9239,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+  languageName: node
+  linkType: hard
+
+"typescript-5.6@npm:typescript@5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
   languageName: node
   linkType: hard
 

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -8069,7 +8069,7 @@ __metadata:
     ts-patch: "npm:^3.2.1"
     tsp1: "npm:ts-patch@1.*.*"
     tsp2: "npm:ts-patch@2.*.*"
-    typescript: "npm:^5.5.4"
+    typescript: "npm:^5.6.3"
     typescript-3: "npm:typescript@3.6.5"
     typescript-4.7: "npm:typescript@4.7.4"
     typescript-5.5: "npm:typescript@5.5.4"
@@ -9232,7 +9232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-5.5@npm:typescript@5.5.4, typescript@npm:^5.5.4":
+"typescript-5.5@npm:typescript@5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
   bin:
@@ -9242,7 +9242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-5.6@npm:typescript@5.6.3":
+"typescript-5.6@npm:typescript@5.6.3, typescript@npm:^5.6.3":
   version: 5.6.3
   resolution: "typescript@npm:5.6.3"
   bin:
@@ -9262,13 +9262,13 @@ __metadata:
   languageName: node
   linkType: soft
 
-"typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
-  version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=74658d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
+  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -8072,6 +8072,7 @@ __metadata:
     typescript: "npm:^5.5.4"
     typescript-3: "npm:typescript@3.6.5"
     typescript-4.7: "npm:typescript@4.7.4"
+    typescript-5.5: "npm:typescript@5.5.4"
     typescript-transform-paths: "portal:../"
   languageName: unknown
   linkType: soft
@@ -9230,6 +9231,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-5.5@npm:typescript@5.5.4, typescript@npm:^5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+  languageName: node
+  linkType: hard
+
 "typescript-transform-paths@portal:../::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "typescript-transform-paths@portal:../::locator=root-workspace-0b6124%40workspace%3A."
@@ -9239,16 +9250,6 @@ __metadata:
     typescript: ">=3.6.5"
   languageName: node
   linkType: soft
-
-"typescript@npm:^5.5.4":
-  version: 5.5.4
-  resolution: "typescript@npm:5.5.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
-  languageName: node
-  linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
   version: 5.5.4


### PR DESCRIPTION
This PR restores compatibility with TypeScript 5.6. It also updates the test suite to be more resilient and explicitly tests against TypeScript 5.5 and 5.6.

I was surprised that TypeScript would break this without releasing a major version. However, if you look at the `getOriginalSourceFile` method we were using, it was marked as `@internal` in the JSDoc: https://github.com/microsoft/TypeScript/blob/c8a7d589e647e19c94150d9892909f3aa93e48eb/src/compiler/utilities.ts#L5416-L5419

Because it was marked as internal, they probably reserved the right to remove this method without a breaking version bump. The other PR to fix this issue (#270) suggested using `getSourceFileOfNode`, but that's also marked as `@internal`: https://github.com/microsoft/TypeScript/blob/11b2930fa2c9f73b0ffb725a9715b8d3c4121bbc/src/compiler/utilities.ts#L965-L975.

Therefore, instead, I updated this code to use `getParseTreeNode` and `isSourceFile`, which are both exposed publicly and not marked as `internal`: https://github.com/microsoft/TypeScript/blob/11b2930fa2c9f73b0ffb725a9715b8d3c4121bbc/src/compiler/utilitiesPublic.ts#L803-L809 / https://github.com/microsoft/TypeScript/blob/11b2930fa2c9f73b0ffb725a9715b8d3c4121bbc/src/compiler/factory/nodeTests.ts#L1013-L1016

By using these methods, we should be more resilient to internal refactoring.

This PR supersedes #270.
Fixes #266