### PR TITLE
fix(paths): respect desired path on case-insensitive file systems

### DIFF
--- a/src/utils/get-relative-path.ts
+++ b/src/utils/get-relative-path.ts
@@ -46,7 +46,10 @@ function getIsFsCaseSensitive() {
   return isCaseSensitiveFilesystem;
 }
 
-function getMatchPortion(from: string, to: string) {
+/**
+ * @private The export is only for unit tests
+ */
+export function getMatchPortion(from: string, to: string) {
   const lowerFrom = from.toLocaleLowerCase();
   const lowerTo = to.toLocaleLowerCase();
 
@@ -58,7 +61,7 @@ function getMatchPortion(from: string, to: string) {
     i++;
   }
 
-  return from.slice(0, i);
+  return to.slice(0, i);
 }
 
 // endregion

--- a/src/utils/get-relative-path.ts
+++ b/src/utils/get-relative-path.ts
@@ -46,9 +46,7 @@ function getIsFsCaseSensitive() {
   return isCaseSensitiveFilesystem;
 }
 
-/**
- * @private The export is only for unit tests
- */
+/** @private The Export is only for unit tests */
 export function getMatchPortion(from: string, to: string) {
   const lowerFrom = from.toLocaleLowerCase();
   const lowerTo = to.toLocaleLowerCase();

--- a/test/tests/get-match-portion.test.ts
+++ b/test/tests/get-match-portion.test.ts
@@ -1,0 +1,18 @@
+import { getMatchPortion } from '../../src/utils/get-relative-path'
+
+describe(`getMatchPortion`, () => {
+	it("works in a simple case", () => {
+		expect(getMatchPortion("/foo/bar", "/foo/quux")).toBe("/foo/");
+	});
+
+	// We use the function getMatchPortion to generate a new path for “to”, so let’s preserve
+	// the case where possible.
+	// Otherwise we are introducing inconsistency for our users, who may have had import from Foo,
+	// their file is named Foo, but we rewrite the path to foo.
+	// Although the file is still accessible in the file system, other tools might reasonably
+	// complain about the unexpected case mismatch.
+	it("prioritizes the casing of the “to” parameter", () => {
+		expect(getMatchPortion("/foo/bar", "/foO/quux")).toBe("/foO/");
+		expect(getMatchPortion("/foo/bar", "/foo/Bonk")).toBe("/foo/B");
+	});
+});

--- a/test/tests/get-match-portion.test.ts
+++ b/test/tests/get-match-portion.test.ts
@@ -1,18 +1,18 @@
-import { getMatchPortion } from '../../src/utils/get-relative-path'
+import { getMatchPortion } from "../../src/utils/get-relative-path";
 
 describe(`getMatchPortion`, () => {
-	it("works in a simple case", () => {
-		expect(getMatchPortion("/foo/bar", "/foo/quux")).toBe("/foo/");
-	});
+  it("works in a simple case", () => {
+    expect(getMatchPortion("/foo/bar", "/foo/quux")).toBe("/foo/");
+  });
 
-	// We use the function getMatchPortion to generate a new path for “to”, so let’s preserve
-	// the case where possible.
-	// Otherwise we are introducing inconsistency for our users, who may have had import from Foo,
-	// their file is named Foo, but we rewrite the path to foo.
-	// Although the file is still accessible in the file system, other tools might reasonably
-	// complain about the unexpected case mismatch.
-	it("prioritizes the casing of the “to” parameter", () => {
-		expect(getMatchPortion("/foo/bar", "/foO/quux")).toBe("/foO/");
-		expect(getMatchPortion("/foo/bar", "/foo/Bonk")).toBe("/foo/B");
-	});
+  // We use the function getMatchPortion to generate a new path for “to”, so let’s preserve
+  // the case where possible.
+  // Otherwise we are introducing inconsistency for our users, who may have had import from Foo,
+  // their file is named Foo, but we rewrite the path to foo.
+  // Although the file is still accessible in the file system, other tools might reasonably
+  // complain about the unexpected case mismatch.
+  it("prioritizes the casing of the “to” parameter", () => {
+    expect(getMatchPortion("/foo/bar", "/foO/quux")).toBe("/foO/");
+    expect(getMatchPortion("/foo/bar", "/foo/Bonk")).toBe("/foo/B");
+  });
 });


### PR DESCRIPTION
Today typescript-transform-paths changes the case of import statements on a case-insensitive file system. I have a file `Foo` and an import `from "./Foo"`, yet after the transformation with typescript-transform-paths, the import looks like `"./foo"`. Even if that import would work on a case-insensitive file system, it seems clearly undesirable.

Note that #187 does _not_ fix the issue above.