### PR TITLE
fix: transform baseUrl-only imports

### DIFF
--- a/src/utils/resolve-path-update-node.ts
+++ b/src/utils/resolve-path-update-node.ts
@@ -1,7 +1,7 @@
 import type ts from "typescript";
 
 import type { VisitorContext } from "../types.ts";
-import { isURL, maybeAddRelativeLocalPrefix } from "./general-utils.ts";
+import { isBaseDir, isURL, maybeAddRelativeLocalPrefix } from "./general-utils.ts";
 import { resolveModuleName } from "./resolve-module-name.ts";
 import { isModulePathsMatch } from "./ts-helpers.ts";
 
@@ -30,11 +30,13 @@ export function resolvePathAndUpdateNode(
   }
 
   /* Resolve Module */
-  // Skip if no paths match found
-  if (!isModulePathsMatch(context, moduleName)) return node;
+  const isPathsMatch = isModulePathsMatch(context, moduleName);
+  const isBaseUrlOnlyMatch = !isPathsMatch && isBaseUrlOnlyModule(context, moduleName);
+  if (!isPathsMatch && !isBaseUrlOnlyMatch) return node;
 
   const res = resolveModuleName(context, moduleName);
   if (!res) return node;
+  if (isBaseUrlOnlyMatch && !isResolvedInBaseUrl(context, res.resolvedPath)) return node;
 
   const { outputPath, resolvedPath } = res;
 
@@ -105,4 +107,16 @@ export function resolvePathAndUpdateNode(
       return undefined;
     }
   }
+}
+
+function isBaseUrlOnlyModule(context: VisitorContext, moduleName: string): boolean {
+  return !!(!context.pathsPatterns && context.compilerOptions.baseUrl && moduleName[0] !== "." && !isURL(moduleName));
+}
+
+function isResolvedInBaseUrl(context: VisitorContext, resolvedPath: string | undefined): boolean {
+  const { baseUrl } = context.compilerOptions;
+  if (!baseUrl || !resolvedPath) return false;
+
+  const { normalizePath } = context.tsInstance;
+  return isBaseDir(normalizePath(baseUrl), normalizePath(resolvedPath));
 }

--- a/test/projects/base-url-only/src/index.ts
+++ b/test/projects/base-url-only/src/index.ts
@@ -1,0 +1,6 @@
+import { localValue } from "local";
+import { nestedValue } from "nested/value";
+import type { CompilerOptions } from "typescript";
+
+export const result = localValue + nestedValue;
+export type { CompilerOptions };

--- a/test/projects/base-url-only/src/local.ts
+++ b/test/projects/base-url-only/src/local.ts
@@ -1,0 +1,1 @@
+export const localValue = 1;

--- a/test/projects/base-url-only/src/nested/value.ts
+++ b/test/projects/base-url-only/src/nested/value.ts
@@ -1,0 +1,1 @@
+export const nestedValue = 2;

--- a/test/projects/base-url-only/tsconfig.json
+++ b/test/projects/base-url-only/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "include": ["src"],
+
+  "compilerOptions": {
+    "target": "es5",
+    "module": "ESNext",
+    "outDir": "__built",
+    "moduleResolution": "node",
+
+    "declaration": true,
+    "baseUrl": "./src",
+
+    "plugins": [
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+    ]
+  }
+}

--- a/test/tests/transformer/base-url-only.test.ts
+++ b/test/tests/transformer/base-url-only.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert";
+import * as path from "node:path";
+import { before, describe, test } from "node:test";
+
+import { projectsPaths, type ts, tsModules } from "../../config.ts";
+import { createTsProgram, getEmitResultFromProgram, type EmittedFiles } from "../../utils/index.ts";
+
+describe(`Transformer -> baseUrl-only Tests`, () => {
+  const projectRoot = path.join(projectsPaths, "base-url-only");
+  const tsConfigFile = path.join(projectRoot, "tsconfig.json");
+
+  for (const [s, tsInstance] of tsModules) {
+    describe(`TypeScript ${s}`, () => {
+      const indexFile = (tsInstance as typeof ts).normalizePath(path.join(projectRoot, "src/index.ts"));
+      let transformedFiles: EmittedFiles = {};
+
+      before(() => {
+        const programWithTransformer = createTsProgram({ tsInstance: tsInstance as typeof ts, tsConfigFile });
+        transformedFiles = getEmitResultFromProgram(programWithTransformer);
+      });
+
+      test(`transforms local baseUrl imports`, () => {
+        assert.match(transformedFiles[indexFile].js, /from "\.\/local"/);
+        assert.match(transformedFiles[indexFile].js, /from "\.\/nested\/value"/);
+      });
+
+      test(`does not transform external package imports`, () => {
+        assert.match(transformedFiles[indexFile].dts, /from "typescript"/);
+      });
+    });
+  }
+});


### PR DESCRIPTION
Closes #146.

This fixes baseUrl-only projects that do not define `paths`. Bare imports are now eligible for transformation when TypeScript resolves them inside `baseUrl`, while external package imports remain unchanged.

Validation:
- `yarn compile`
- `yarn test`
- `yarn prettier --check src/utils/resolve-path-update-node.ts test/tests/transformer/base-url-only.test.ts test/projects/base-url-only/tsconfig.json test/projects/base-url-only/src/index.ts test/projects/base-url-only/src/local.ts test/projects/base-url-only/src/nested/value.ts`
- `yarn eslint src/utils/resolve-path-update-node.ts test/tests/transformer/base-url-only.test.ts test/projects/base-url-only/src/index.ts test/projects/base-url-only/src/local.ts test/projects/base-url-only/src/nested/value.ts`