### PR TITLE
fix: handle accessors in declaration return types

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -151,5 +151,32 @@ export function nodeVisitor(this: VisitorContext, node: ts.Node): ts.Node | unde
       factory.updateModuleDeclaration(node, node.modifiers, p, node.body),
     );
 
+  /*
+   * TypeScript suspends the surrounding lexical environment while visiting a
+   * function's return type. Starting another lexical environment for an
+   * accessor inside that type currently triggers a compiler assertion
+   * (microsoft/TypeScript#58020). Visit bodyless accessors manually so import
+   * types in their annotations are still transformed without entering another
+   * parameter-list lexical environment.
+   */
+  if (tsInstance.isGetAccessorDeclaration(node) && !node.body)
+    return factory.updateGetAccessorDeclaration(
+      node,
+      node.modifiers,
+      node.name,
+      node.parameters,
+      tsInstance.visitNode(node.type, this.getVisitor(), tsInstance.isTypeNode),
+      node.body,
+    );
+
+  if (tsInstance.isSetAccessorDeclaration(node) && !node.body)
+    return factory.updateSetAccessorDeclaration(
+      node,
+      node.modifiers,
+      node.name,
+      tsInstance.visitNodes(node.parameters, this.getVisitor(), tsInstance.isParameter),
+      node.body,
+    );
+
   return tsInstance.visitEachChild(node, this.getVisitor(), transformationContext);
 }

--- a/test/projects/general/core/index.ts
+++ b/test/projects/general/core/index.ts
@@ -24,6 +24,21 @@ const n: NoRuntimecodeHere = null as any;
 subs(2, 3);
 const a = new A("");
 
+export function MaySkipHooks() {
+  class SkippableOnce {
+    get skipHooks() {
+      return undefined;
+    }
+  }
+
+  return SkippableOnce;
+}
+
+export declare function AccessorTypes(): {
+  get value(): import("@utils/types-only").NoRuntimecodeHere;
+  set value(value: import("@utils/types-only").NoRuntimecodeHere);
+};
+
 (async function () {
   const Logger = await (await import("@dynamic/logger")).Logger;
   const logger = new Logger();

--- a/test/tests/transformer/general.test.ts
+++ b/test/tests/transformer/general.test.ts
@@ -31,6 +31,7 @@ const getExpected = (tsInstance: typeof ts, fileName: string, original: string, 
 describe(`Transformer -> General Tests`, () => {
   const projectRoot = path.join(projectsPaths, "general");
   const tsConfigFile = path.join(projectRoot, "tsconfig.json");
+  const coreIndexFile = path.join(projectRoot, "core/index.ts");
 
   for (const [s, tsInstance] of tsModules)
     describe(`TypeScript ${s}`, () => {
@@ -63,5 +64,15 @@ describe(`Transformer -> General Tests`, () => {
           test(`dts matches`, (t) => t.assert.strictEqual(transformed.dts, expected.dts));
         });
       }
+
+      test(`handles accessors in declaration return types`, (t) => {
+        const dts = transformedFiles[coreIndexFile].dts;
+
+        t.assert.match(dts, /export declare function MaySkipHooks\(\): \{[\s\S]*?get skipHooks\(\): any;[\s\S]*?\};/);
+        t.assert.match(
+          dts,
+          /export declare function AccessorTypes\(\): \{\s*get value\(\): import\("\.\.\/utils\/types-only"\)\.NoRuntimecodeHere;\s*set value\(value: import\("\.\.\/utils\/types-only"\)\.NoRuntimecodeHere\);\s*\};/,
+        );
+      });
     });
 });


### PR DESCRIPTION
## Summary

- handle bodyless accessors without entering a nested parameter-list lexical environment
- continue transforming import types in getter and setter annotations
- add explicit regression coverage for the TypeScript 5.9 declaration-emit crash

## Root cause

TypeScript 5.9 suspends the surrounding lexical environment while visiting a function return type. Calling `visitEachChild` for an accessor nested in that type attempts to start another lexical environment and triggers `Debug Failure. False expression: Lexical environment is suspended.` This is tracked upstream in microsoft/TypeScript#58020.

The transformer now updates bodyless accessors directly while still visiting their type annotations and parameters.

Fixes #437

## Validation

- `yarn fmt:check`
- `yarn lint`
- `yarn build`
- full test suite on Node.js 22: 52 passed, 0 failed, 1 skipped

## AI assistance disclosure

OpenAI Codex was used to investigate the issue, draft the implementation and regression coverage, and run the validation commands listed above.
